### PR TITLE
Add Lato google fonts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,6 +18,9 @@
 	<link rel="alternate" type="application/rss+xml" title="{{site.title}}" href="/feed.xml">
 	
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
+	<link rel="preconnect" href="https://fonts.googleapis.com">
+	<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+	<link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,100;0,300;0,400;0,700;0,900;1,100;1,300;1,400;1,700;1,900&display=swap" rel="stylesheet">
 
 	{% if jekyll.environment == 'production' %}
 		{% include analytics.html %}


### PR DESCRIPTION
Site breaks on Linux browser due to missing local font, this adds the google font to fix that.